### PR TITLE
Extended DataProvider for multiple arrays

### DIFF
--- a/src/DataProvider.cpp
+++ b/src/DataProvider.cpp
@@ -1,7 +1,8 @@
 #include "DataProvider.h"
 
-DataProvider::DataProvider(MPI_Comm comm, size_t n)
-        : comm_(comm), win_(MPI_WIN_NULL), baseptr_(nullptr), n_(0) {
+DataProvider::DataProvider(MPI_Comm comm, const std::vector<std::string>& names,
+                           const std::vector<std::size_t>& nsizes)
+        : comm_(comm) {
 
     // Split to shared-memory communicator
     MPI_Comm_split_type(
@@ -13,40 +14,49 @@ DataProvider::DataProvider(MPI_Comm comm, size_t n)
 
     MPI_Comm_rank(this->shmcomm_, &this->shmRank_);
 
-    // number of element in the shared array
-    this->n_ = n;
+    // // Check number of elements
+    // if (names.size() != nsizes.size()) {
+    //     throw std::invalid_argument("The size of names and nsizes must be the same");
+    // }
 
-    MPI_Aint bytes = 0;
+    for (size_t i = 0; i < names.size(); ++i) {
 
-    // Only origin rank allocates memory
-    if (this->shmRank_ == 0) { // local rank that stores the data is 0 
-        bytes = static_cast<MPI_Aint>(this->n_) * sizeof(double);
-    }
+        MPI_Aint bytes = 0;
+        // Only origin rank allocates memory
+        if (this->shmRank_ == 0) { // local rank 0 stores the data
+            bytes = static_cast<MPI_Aint>(nsizes[i]) * sizeof(double);
+        }
 
-    // Allocate shared memory window
-    MPI_Win_allocate_shared(
-        bytes,
-        sizeof(double),
-        MPI_INFO_NULL,
-        this->shmcomm_,
-        &this->baseptr_,
-        &this->win_);
+        double* baseptr = nullptr;
+        MPI_Win win = MPI_WIN_NULL;
 
-    // Everyone queries origin memory
-    MPI_Aint size;
-    int disp_unit;
+        // Allocate shared memory window for this array
+        MPI_Win_allocate_shared(bytes, sizeof(double), MPI_INFO_NULL, this->shmcomm_, &baseptr, &win);
 
-    MPI_Win_shared_query(
-        this->win_,
+        // Everyone queries origin memory
+        MPI_Aint size;
+        int disp_unit;
+
+        MPI_Win_shared_query(win,
         0, // query rank 0's allocation
         &size,
         &disp_unit,
-        &this->baseptr_);
+        &baseptr);
+
+        // Store the base pointer, number of elements, and window in the data map
+        this->data_[names[i]] = std::make_tuple(baseptr, nsizes[i], win);
+    }
+  
 }
 
 DataProvider::~DataProvider() {
-    if (this->win_ != MPI_WIN_NULL)
-        MPI_Win_free(&this->win_);
+
+    for (auto& [name, tuple] : this->data_) {
+        auto& [baseptr, n, win] = tuple;
+        if (win != MPI_WIN_NULL) {
+            MPI_Win_free(&win);
+        }
+    }
 
     if (this->shmcomm_ != MPI_COMM_NULL)
         MPI_Comm_free(&this->shmcomm_);

--- a/src/DataProvider.cpp
+++ b/src/DataProvider.cpp
@@ -1,10 +1,10 @@
 #include "DataProvider.h"
 
-DataProvider::DataProvider(MPI_Comm comm, const std::vector<std::string>& names,
-                           const std::vector<std::size_t>& nsizes)
+DataProvider::DataProvider(MPI_Comm comm, 
+                           const std::vector< std::pair<std::string, std::size_t> >& nameSizePairs)
         : comm_(comm), shmcomm_(MPI_COMM_NULL), shmRank_(-1) {
 
-    // Split to shared-memory communicator
+    // Split to get the shared-memory communicator
     MPI_Comm_split_type(
         this->comm_,
         MPI_COMM_TYPE_SHARED,
@@ -14,17 +14,15 @@ DataProvider::DataProvider(MPI_Comm comm, const std::vector<std::string>& names,
 
     MPI_Comm_rank(this->shmcomm_, &this->shmRank_);
 
-    // // Check number of elements
-    // if (names.size() != nsizes.size()) {
-    //     throw std::invalid_argument("The size of names and nsizes must be the same");
-    // }
+    for (const auto& ns : nameSizePairs) {
 
-    for (size_t i = 0; i < names.size(); ++i) {
+        const std::string& name = ns.first;
+        std::size_t size = ns.second;
 
         MPI_Aint bytes = 0;
         // Only origin rank allocates memory
         if (this->shmRank_ == 0) { // local rank 0 stores the data
-            bytes = static_cast<MPI_Aint>(nsizes[i]) * sizeof(double);
+            bytes = static_cast<MPI_Aint>(size) * sizeof(double);
         }
 
         double* baseptr = nullptr;
@@ -34,17 +32,17 @@ DataProvider::DataProvider(MPI_Comm comm, const std::vector<std::string>& names,
         MPI_Win_allocate_shared(bytes, sizeof(double), MPI_INFO_NULL, this->shmcomm_, &baseptr, &win);
 
         // Everyone queries origin memory
-        MPI_Aint size;
+        MPI_Aint size_mpi;
         int disp_unit;
 
         MPI_Win_shared_query(win,
         0, // query rank 0's allocation
-        &size,
+        &size_mpi,
         &disp_unit,
         &baseptr);
 
         // Store the base pointer, number of elements, and window in the data map
-        this->data_[names[i]] = std::make_tuple(baseptr, nsizes[i], win);
+        this->data_[name] = std::make_tuple(baseptr, size, win);
     }
   
 }

--- a/src/DataProvider.cpp
+++ b/src/DataProvider.cpp
@@ -2,7 +2,7 @@
 
 DataProvider::DataProvider(MPI_Comm comm, const std::vector<std::string>& names,
                            const std::vector<std::size_t>& nsizes)
-        : comm_(comm) {
+        : comm_(comm), shmcomm_(MPI_COMM_NULL), shmRank_(-1) {
 
     // Split to shared-memory communicator
     MPI_Comm_split_type(

--- a/src/DataProvider.h
+++ b/src/DataProvider.h
@@ -2,6 +2,10 @@
 #include <cstddef>
 #include <cstring>
 #include <stdexcept>
+#include <vector>
+#include <string>
+#include <map>
+#include <tuple>
 
 #ifndef DATA_PROVIDER_H
 #define DATA_PROVIDER_H
@@ -16,9 +20,10 @@ public:
     /**
     * @brief Constructor
     * @param comm root MPI communicator, the shared memory communicator will be derived from this
-    * @param n Number of elements in the data array
+    * @param names shared array names
+    * @param nsizes number of elements of each shared array, the order should be the same as the order of names
     */  
-    DataProvider(MPI_Comm comm, size_t n);
+    DataProvider(MPI_Comm comm, const std::vector<std::string>& names, const std::vector<std::size_t>& n);
 
     ~DataProvider();
 
@@ -38,25 +43,32 @@ public:
      * @brief Get a pointer to the shared data array
      * @return pointer to the shared data array
      */
-    double* getDataPtr() const {
-        return baseptr_;
+    double* getDataPtr(const std::string& name) const {
+        auto it = this->data_.find(name);
+        return it != this->data_.end() ? std::get<0>(it->second) : nullptr;
     }
 
     /**
      * @brief Get the number of elements in the shared data array
      * @return number of elements in the shared data array
      */
-    size_t getNumElements() const {
-        return n_;
+    size_t getNumElements(const std::string& name) const {
+        auto it = this->data_.find(name);
+        return it != this->data_.end() ? std::get<1>(it->second) : 0;
+    }
+
+    /**
+     * Get the MPI shm communicator
+     * @return the MPI shm communicator
+     */
+    MPI_Comm getShmComm() const {
+        return this->shmcomm_;
     }
 
 private:
     MPI_Comm comm_;
     MPI_Comm shmcomm_;
-    MPI_Win win_;
-
-    double* baseptr_;
-    size_t n_;
+    std::map< std::string, std::tuple<double*, std::size_t, MPI_Win> > data_;
     int shmRank_;
 };
 

--- a/src/DataProvider.h
+++ b/src/DataProvider.h
@@ -4,7 +4,7 @@
 #include <stdexcept>
 #include <vector>
 #include <string>
-#include <map>
+#include <unordered_map>
 #include <tuple>
 
 #ifndef DATA_PROVIDER_H
@@ -68,7 +68,7 @@ public:
 private:
     MPI_Comm comm_;
     MPI_Comm shmcomm_;
-    std::map< std::string, std::tuple<double*, std::size_t, MPI_Win> > data_;
+    std::unordered_map< std::string, std::tuple<double*, std::size_t, MPI_Win> > data_;
     int shmRank_;
 };
 

--- a/src/DataProvider.h
+++ b/src/DataProvider.h
@@ -17,13 +17,15 @@ class DataProvider {
 
 public:
 
+    DataProvider(const DataProvider&) = delete;
+    DataProvider& operator=(const DataProvider&) = delete;
+
     /**
     * @brief Constructor
     * @param comm root MPI communicator, the shared memory communicator will be derived from this
-    * @param names shared array names
-    * @param nsizes number of elements of each shared array, the order should be the same as the order of names
+    * @param nameSizePairs vector of pairs containing shared array names and their sizes
     */  
-    DataProvider(MPI_Comm comm, const std::vector<std::string>& names, const std::vector<std::size_t>& n);
+    DataProvider(MPI_Comm comm, const std::vector<std::pair<std::string, std::size_t> >& nameSizePairs);
 
     ~DataProvider();
 
@@ -42,6 +44,10 @@ public:
     /**
      * @brief Get a pointer to the shared data array
      * @return pointer to the shared data array
+     * @note the returned pointer is valid only within the same shared memory node, and should not be used for MPI communication 
+     * across different nodes. Additionally, the caller should ensure that the shared data array is properly synchronized 
+     * (e.g., using MPI_Barrier) before accessing the data to ensure visibility of the data updates across all ranks on the 
+     * same node.
      */
     double* getDataPtr(const std::string& name) const {
         auto it = this->data_.find(name);

--- a/tests/testDataProvider.cxx
+++ b/tests/testDataProvider.cxx
@@ -43,8 +43,6 @@ int main(int argc, char** argv)
             {"oxygen", static_cast<std::size_t>(numData)}
         };
 
-        std::size_t n = static_cast<std::size_t>(numData);
-        std::vector<std::size_t> nsizes = {n, n, n, n};
         DataProvider dataProvider(MPI_COMM_WORLD, nameSizePairs);
 
         // set the field values

--- a/tests/testDataProvider.cxx
+++ b/tests/testDataProvider.cxx
@@ -34,27 +34,36 @@ int main(int argc, char** argv)
     // Make sure the DataProvider destructor is called before MPI_Finalize
     {
         const int numData = cmdLine.get<int>("-nd");
-        DataProvider dataProvider(MPI_COMM_WORLD, numData);
 
-        // get the pointer to the shared data array
-        double* shmDataPtr = dataProvider.getDataPtr();
+        std::vector<std::string> names = {"un", "vn", "tempn", "oxygen"};
+        std::size_t n = static_cast<std::size_t>(numData);
+        std::vector<std::size_t> nsizes = {n, n, n, n};
+        DataProvider dataProvider(MPI_COMM_WORLD, names, nsizes);
 
+        // set the field values
         if (dataProvider.isShmRoot()) {
-
-            // Only the shmRoot rank on each shared-memory node initializes the data. There are as many shmRoot
-            // ranks as there are nodes.
-            for (auto i = 0; i < numData; ++i) {
-                shmDataPtr[i] = (double) (i + 1);
+            for (size_t i = 0; i < names.size(); ++i) {
+                double* dataPtr = dataProvider.getDataPtr(names[i]);
+                std::size_t numData = dataProvider.getNumElements(names[i]);
+                for (auto j = 0; j < numData; ++j) {
+                    // fill the data with some values, e.g., 1, 2, ..., numData for the first array, 2, 4, ..., 2*numData for the second array, etc.
+                    dataPtr[j] = (double) (j + 1) * (i + 1);
+                }
             }
         }
 
         // synchronize shared-memory access to make sure the data are visible to all ranks on the same node
-        MPI_Barrier(MPI_COMM_WORLD);
+        MPI_Barrier(dataProvider.getShmComm());
 
         // from now on, all ranks on the same shared-memory node can directly read the shared data array 
         // without MPI communication
-        double checksum = std::accumulate(shmDataPtr, shmDataPtr + numData, 0.0);
-        double expectedChecksum = 0.5 * (numData + 1) * numData; // sum of 1, 2, ..., numData
+        double checksum = 0.0;
+        for (auto name : names) {
+            double* dataPtr = dataProvider.getDataPtr(name);
+            checksum += std::accumulate(dataPtr, dataPtr + dataProvider.getNumElements(name), 0.0);
+        }
+        std::size_t numFields = names.size();
+        double expectedChecksum = 0.5 * (numData + 1) * numData * 0.5 * (numFields + 1) * numFields;
 
         // get the rank of the calling process in the shared memory communicator
         int shmRank = dataProvider.getShmRank();

--- a/tests/testDataProvider.cxx
+++ b/tests/testDataProvider.cxx
@@ -36,17 +36,23 @@ int main(int argc, char** argv)
         const int numData = cmdLine.get<int>("-nd");
 
         // list of fields
-        std::vector<std::string> names = {"un", "vn", "tempn", "oxygen"};
+        std::vector<std::pair<std::string, std::size_t>> nameSizePairs = {
+            {"un", static_cast<std::size_t>(numData)},
+            {"vn", static_cast<std::size_t>(numData)},
+            {"tempn", static_cast<std::size_t>(numData)},
+            {"oxygen", static_cast<std::size_t>(numData)}
+        };
 
         std::size_t n = static_cast<std::size_t>(numData);
         std::vector<std::size_t> nsizes = {n, n, n, n};
-        DataProvider dataProvider(MPI_COMM_WORLD, names, nsizes);
+        DataProvider dataProvider(MPI_COMM_WORLD, nameSizePairs);
 
         // set the field values
         if (dataProvider.isShmRoot()) {
-            for (size_t i = 0; i < names.size(); ++i) {
-                double* dataPtr = dataProvider.getDataPtr(names[i]);
-                std::size_t numData = dataProvider.getNumElements(names[i]);
+            for (size_t i = 0; i < nameSizePairs.size(); ++i) {
+                const std::string& name = nameSizePairs[i].first;
+                double* dataPtr = dataProvider.getDataPtr(name);
+                std::size_t numData = dataProvider.getNumElements(name);
                 for (auto j = 0; j < numData; ++j) {
                     // fill the data with some values, e.g., 1, 2, ..., numData for the first array, 
                     // 2, 4, ..., 2*numData for the second array, etc.
@@ -61,11 +67,12 @@ int main(int argc, char** argv)
         // from now on, all ranks on the same shared-memory node can directly read the shared data array 
         // without MPI communication
         double checksum = 0.0;
-        for (auto name : names) {
+        for (auto nameSize : nameSizePairs) {
+            const std::string& name = nameSize.first;
             double* dataPtr = dataProvider.getDataPtr(name);
             checksum += std::accumulate(dataPtr, dataPtr + dataProvider.getNumElements(name), 0.0);
         }
-        std::size_t numFields = names.size();
+        std::size_t numFields = nameSizePairs.size();
         double expectedChecksum = 0.5 * (numData + 1) * numData * 0.5 * (numFields + 1) * numFields;
 
         // get the rank of the calling process in the shared memory communicator

--- a/tests/testDataProvider.cxx
+++ b/tests/testDataProvider.cxx
@@ -35,7 +35,9 @@ int main(int argc, char** argv)
     {
         const int numData = cmdLine.get<int>("-nd");
 
+        // list of fields
         std::vector<std::string> names = {"un", "vn", "tempn", "oxygen"};
+
         std::size_t n = static_cast<std::size_t>(numData);
         std::vector<std::size_t> nsizes = {n, n, n, n};
         DataProvider dataProvider(MPI_COMM_WORLD, names, nsizes);
@@ -46,7 +48,8 @@ int main(int argc, char** argv)
                 double* dataPtr = dataProvider.getDataPtr(names[i]);
                 std::size_t numData = dataProvider.getNumElements(names[i]);
                 for (auto j = 0; j < numData; ++j) {
-                    // fill the data with some values, e.g., 1, 2, ..., numData for the first array, 2, 4, ..., 2*numData for the second array, etc.
+                    // fill the data with some values, e.g., 1, 2, ..., numData for the first array, 
+                    // 2, 4, ..., 2*numData for the second array, etc.
                     dataPtr[j] = (double) (j + 1) * (i + 1);
                 }
             }


### PR DESCRIPTION
Hi @innasenina 
This PR extends the previous DataProvider implementation by creating as many shared memory windows as there are arrays. So for example:

        // list of fields
        std::vector<std::pair<std::string, std::size_t>> nameSizePairs = {
            {"un", static_cast<std::size_t>(numData)},
            {"vn", static_cast<std::size_t>(numData)},
            {"tempn", static_cast<std::size_t>(numData)},
            {"oxygen", static_cast<std::size_t>(numData)}
        };

        DataProvider dataProvider(MPI_COMM_WORLD, nameSizePairs);

Then to set or access a field (for instance)

double* dataPtr = dataProvider.getDataPtr("oxygen");

Once the data are read on shmRank 0, be sure to use MPI_Barrier(shmComm);

