### PR TITLE
Add ageMature to the dependency analyzer to remove na/2 idle-worker cap

### DIFF
--- a/src/SeapodymCohortDependencyAnalyzer.cpp
+++ b/src/SeapodymCohortDependencyAnalyzer.cpp
@@ -1,10 +1,15 @@
 #include "SeapodymCohortDependencyAnalyzer.h"
 
-SeapodymCohortDependencyAnalyzer::SeapodymCohortDependencyAnalyzer(int numAgeGroups, int numTimeSteps) {
+SeapodymCohortDependencyAnalyzer::SeapodymCohortDependencyAnalyzer(int numAgeGroups, int numTimeSteps, int ageMature) {
 
     this->numAgeGroups = numAgeGroups;
     this->numTimeSteps = numTimeSteps;
     this->numIds = numAgeGroups + numTimeSteps - 1;
+    // a newborn cohort only reads mature ages of the previous time step, so younger
+    // age classes (0..ageMature-1) are NOT real dependencies; including them delays
+    // consecutive births and makes workers idle. This fix removes current cap ~na/2.
+    if (ageMature < 0) ageMature = 0;
+    if (ageMature >= numAgeGroups) ageMature = 0;   // guard against a degenerate value
 
     // set the min/mas step indices
     for (int task_id = 0; task_id < this->numIds; ++task_id) {
@@ -28,7 +33,7 @@ SeapodymCohortDependencyAnalyzer::SeapodymCohortDependencyAnalyzer(int numAgeGro
 
         std::set< std::array<int, 2>> dep_set;
 
-        for (int step = 0; step < this->numAgeGroups; ++step) {
+        for (int step = ageMature; step < this->numAgeGroups; ++step) {
 
             int otherTaskId = task_id - step - 1;
             dep_set.insert(std::array<int, 2>{otherTaskId, step});

--- a/src/SeapodymCohortDependencyAnalyzer.h
+++ b/src/SeapodymCohortDependencyAnalyzer.h
@@ -53,8 +53,12 @@ public:
      * 
      * @param numAgeGroups number of age groups (e.g. 3 in the above example)
      * @param numTimeSteps number of tiem steps (e.g. 5 in the above example)
+     * @param ageMature index of the first mature age class. A newborn cohort only
+     *        needs the densities of mature age classes (ageMature..numAgeGroups-1)
+     *        of the previous time step, so dependencies on younger ages are omitted.
+     *        Defaults to 0 = dependence on the full state at time t-1.
      */
-    SeapodymCohortDependencyAnalyzer(int numAgeGroups, int numTimeSteps);
+    SeapodymCohortDependencyAnalyzer(int numAgeGroups, int numTimeSteps, int ageMature = 0);
 
     /**
      * Get the number of cohorts


### PR DESCRIPTION
Each new cohort was made to depend on the full previous-step state (age classes 0..na-1), even though spawning only requires the mature ages. Those extra dependencies forced newborns to wait for the 't-1' newborns. This created the ~na/2 cap because only half of the workers were active. The factor of 2 comes from the duration of the InitializeCohort taking about as long as a stepForward, so the 'a=0' step costs ~2x a normal stepForward.

The default value of ageMature = 0 leaves existing calls unaffected. Correctness (checksums) is preserved. All workers are now active.