### PR TITLE
Add support for A+ cohort

### DIFF
--- a/src/SeapodymCohortDependencyAnalyzer.cpp
+++ b/src/SeapodymCohortDependencyAnalyzer.cpp
@@ -1,6 +1,6 @@
 #include "SeapodymCohortDependencyAnalyzer.h"
 
-SeapodymCohortDependencyAnalyzer::SeapodymCohortDependencyAnalyzer(int numAgeGroups, int numTimeSteps, int ageMature) {
+SeapodymCohortDependencyAnalyzer::SeapodymCohortDependencyAnalyzer(int numAgeGroups, int numTimeSteps, int ageMature, bool aPlusCohort) {
 
     this->numAgeGroups = numAgeGroups;
     this->numTimeSteps = numTimeSteps;
@@ -11,7 +11,7 @@ SeapodymCohortDependencyAnalyzer::SeapodymCohortDependencyAnalyzer(int numAgeGro
     if (ageMature < 0) ageMature = 0;
     if (ageMature >= numAgeGroups) ageMature = 0;   // guard against a degenerate value
 
-    // set the min/mas step indices
+    // set the min/max step indices
     for (int task_id = 0; task_id < this->numIds; ++task_id) {
 
         this->stepBegMap[task_id] = std::max(0, this->numAgeGroups - 1 - task_id);
@@ -29,6 +29,7 @@ SeapodymCohortDependencyAnalyzer::SeapodymCohortDependencyAnalyzer(int numAgeGro
         this->dependencyMap[task_id] = std::set< std::array<int, 2>>();
     }
 
+    // add "living" cohort dependencies
     for (int task_id = this->numAgeGroups; task_id < this->numIds; ++task_id) {
 
         std::set< std::array<int, 2>> dep_set;
@@ -41,6 +42,17 @@ SeapodymCohortDependencyAnalyzer::SeapodymCohortDependencyAnalyzer(int numAgeGro
         }
     
         this->dependencyMap[task_id] = dep_set;
+    }
+
+    if (aPlusCohort) {
+        // add the A+ cohort dependencies. To fit with the existing dependency representation, cohort Id: {(otherCohortId, step), ...}
+        // the A+ cohort is treated as a separate cohort with a negative id at each time step. The (negative) id is -timeStep.
+        for (auto timeStep = 1; timeStep < this->numTimeSteps; ++timeStep) {
+            this->dependencyMap[-timeStep] = std::set< std::array<int, 2>>{{timeStep - 1, this->numAgeGroups - 1}};
+        // Not sure if we need this
+        this->stepBegMap[-timeStep] = 0;
+        this->stepEndMap[-timeStep] = 1;
+        }
     }
 
 }

--- a/src/SeapodymCohortDependencyAnalyzer.cpp
+++ b/src/SeapodymCohortDependencyAnalyzer.cpp
@@ -45,14 +45,29 @@ SeapodymCohortDependencyAnalyzer::SeapodymCohortDependencyAnalyzer(int numAgeGro
     }
 
     if (aPlusCohort) {
-        // add the A+ cohort dependencies. To fit with the existing dependency representation, cohort Id: {(otherCohortId, step), ...}
-        // the A+ cohort is treated as a separate cohort with a negative id at each time step. The (negative) id is -timeStep.
+
+        // add the A+ cohort dependencies. To fit with the existing dependency representation, cohort Id: {(otherCohortId, step), ...},
+        // the A+ cohort is treated as a separate cohort with a negative id at each time step
+
+        // first A+ (task_id = -1) has no dependency; add it to all maps
+        this->dependencyMap[-1] = std::set< std::array<int, 2>>();
+        this->stepBegMap[-1] = 0;
+        this->stepEndMap[-1] = 1;
+
         for (auto timeStep = 1; timeStep < this->numTimeSteps; ++timeStep) {
-            this->dependencyMap[-timeStep] = std::set< std::array<int, 2>>{{timeStep - 1, this->numAgeGroups - 1}};
-        // Not sure if we need this
-        this->stepBegMap[-timeStep] = 0;
-        this->stepEndMap[-timeStep] = 1;
+
+            // use negative IDs
+            int aPlusId = -timeStep - 1;
+
+            // depends on the last step of the oldest cohort and on the A+ at the previous step
+            this->dependencyMap[aPlusId] = std::set< std::array<int, 2>>{{timeStep - 1, this->numAgeGroups - 1}, {aPlusId + 1, 0}};
+
+            // treat each A+ cohort at each step as a separate cohort with a single step
+            this->stepBegMap[aPlusId] = 0;
+            this->stepEndMap[aPlusId] = 1;
         }
+
+        this->numIds += this->numTimeSteps;
     }
 
 }
@@ -62,9 +77,13 @@ SeapodymCohortDependencyAnalyzer::getNumberOfCohorts() const {
     return this->numIds;
 }
 
-int 
+int
 SeapodymCohortDependencyAnalyzer::getNumberOfCohortSteps() const {
-    return this->numAgeGroups * this->numTimeSteps;
+    int total = 0;
+    for (const auto& [id, beg] : this->stepBegMap) {
+        total += this->stepEndMap.at(id) - beg;
+    }
+    return total;
 }
 
 std::map<int, int>

--- a/src/SeapodymCohortDependencyAnalyzer.h
+++ b/src/SeapodymCohortDependencyAnalyzer.h
@@ -57,8 +57,9 @@ public:
      *        needs the densities of mature age classes (ageMature..numAgeGroups-1)
      *        of the previous time step, so dependencies on younger ages are omitted.
      *        Defaults to 0 = dependence on the full state at time t-1.
+     * @param aPlusCohort whether to add the A+ cohort dependency
      */
-    SeapodymCohortDependencyAnalyzer(int numAgeGroups, int numTimeSteps, int ageMature = 0);
+    SeapodymCohortDependencyAnalyzer(int numAgeGroups, int numTimeSteps, int ageMature = 0, bool aPlusCohort = false);
 
     /**
      * Get the number of cohorts

--- a/src/SeapodymCohortDependencyAnalyzer.h
+++ b/src/SeapodymCohortDependencyAnalyzer.h
@@ -34,7 +34,7 @@ private:
     // number of time steps
     int numTimeSteps;
 
-    // total number of cohorts
+    // total number of cohorts (excluding A+)
     int numIds;
 
     // cohort Id: starting step index
@@ -62,7 +62,7 @@ public:
     SeapodymCohortDependencyAnalyzer(int numAgeGroups, int numTimeSteps, int ageMature = 0, bool aPlusCohort = false);
 
     /**
-     * Get the number of cohorts
+     * Get the number of cohorts (excluding A+)
      * 
      * In the above example, there are 7 cohorts with Ids 0..6
      * @return number

--- a/src/Tags.h
+++ b/src/Tags.h
@@ -4,5 +4,6 @@
 #define START_TASK_TAG 0
 #define END_TASK_TAG 1
 #define WORKER_AVAILABLE_TAG 2
+#define SHUTDOWN_TAG 3
 
 #endif

--- a/src/TaskStepManager.cpp
+++ b/src/TaskStepManager.cpp
@@ -41,7 +41,7 @@ TaskStepManager::run() const {
 
     // std::list gives O(1) erase-by-iterator during task assignment
     std::list<int> task_queue;
-    for (int i = 0; i < this->numTasks; ++i) task_queue.push_back(i);
+    for (const auto& [task_id, beg] : this->stepBegMap) task_queue.push_back(task_id);
 
     std::set<int> active_workers;
     for (int i = 1; i < size; ++i) active_workers.insert(i);
@@ -111,10 +111,10 @@ TaskStepManager::run() const {
     }
 
     // Shutdown all workers
-    const int stop = -1;
+    const int stop = 0;
     for (int worker = 1; worker < size; ++worker) {
         std::cout << "[Manager] shutting down worker " << worker << "\n";
-        MPI_Send(&stop, 1, MPI_INT, worker, START_TASK_TAG, this->comm);
+        MPI_Send(&stop, 1, MPI_INT, worker, SHUTDOWN_TAG, this->comm);
     }
 
     return results;

--- a/src/TaskStepWorker.cpp
+++ b/src/TaskStepWorker.cpp
@@ -30,10 +30,11 @@ TaskStepWorker::run() const {
         // Get the task_id to operate on
         int task_id;
         logger->info("Waiting for manager to send a task...");
-        MPI_Recv(&task_id, 1, MPI_INT, managerRank, START_TASK_TAG, this->comm, MPI_STATUS_IGNORE);
+        MPI_Status recv_status;
+        MPI_Recv(&task_id, 1, MPI_INT, managerRank, MPI_ANY_TAG, this->comm, &recv_status);
         logger->info("Received task {}", task_id);
 
-        if (task_id == -1) {
+        if (recv_status.MPI_TAG == SHUTDOWN_TAG) {
             // Shutdown
             logger->info("Shutting down.");
             break;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -116,6 +116,10 @@ set_tests_properties(testTaskStepFarmingCohortNa5Nt10Nw3Mature0 PROPERTIES PASS_
 add_test(NAME testTaskStepFarmingCohortNa5Nt10Nw3Mature1 COMMAND mpiexec -n 4 ./testTaskStepFarmingCohort -na 5 -nt 10 -nd 100000 -nm 1 -age_mature 1)
 set_tests_properties(testTaskStepFarmingCohortNa5Nt10Nw3Mature1 PROPERTIES PASS_REGULAR_EXPRESSION "checksum: 32500000")
 
+add_test(NAME testTaskStepFarmingCohortNa5Nt10Nw3Mature1APlus COMMAND mpiexec -n 4 ./testTaskStepFarmingCohortAPlus -na 5 -nt 10 -nd 100000 -nm 1 -age_mature 1)
+set_tests_properties(testTaskStepFarmingCohortNa5Nt10Nw3Mature1APlus PROPERTIES PASS_REGULAR_EXPRESSION "checksum: 27000000")
+
+
 add_test(NAME testTaskStepFarmingCohortNa5Nt10Nw3 COMMAND mpiexec -n 4 ./testTaskStepFarmingCohort -na 5 -nt 10 -nd 100000 -nm 1)
 set_tests_properties(testTaskStepFarmingCohortNa5Nt10Nw3 PROPERTIES PASS_REGULAR_EXPRESSION "checksum: 32500000")
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -43,6 +43,9 @@ target_link_libraries(testTaskStepFarming PRIVATE seapodym_api spdlog::spdlog fm
 add_executable(testTaskStepFarmingCohort testTaskStepFarmingCohort.cxx)
 target_link_libraries(testTaskStepFarmingCohort PRIVATE seapodym_api spdlog::spdlog fmt::fmt)
 
+add_executable(testTaskStepFarmingCohortAPlus testTaskStepFarmingCohortAPlus.cxx)
+target_link_libraries(testTaskStepFarmingCohortAPlus PRIVATE seapodym_api spdlog::spdlog fmt::fmt)
+
 add_executable(testDistDataCollector testDistDataCollector.cxx)
 target_link_libraries(testDistDataCollector PRIVATE seapodym_api)
 
@@ -106,6 +109,12 @@ set_tests_properties(testTaskStepFarmingCohortNa1Nt2 PROPERTIES PASS_REGULAR_EXP
 
 add_test(NAME testTaskStepFarmingCohortNa5Nt10 COMMAND mpiexec -n 6 ./testTaskStepFarmingCohort -na 5 -nt 10 -nd 100000 -nm 1)
 set_tests_properties(testTaskStepFarmingCohortNa5Nt10 PROPERTIES PASS_REGULAR_EXPRESSION "checksum: 32500000")
+
+add_test(NAME testTaskStepFarmingCohortNa5Nt10Nw3Mature0 COMMAND mpiexec -n 4 ./testTaskStepFarmingCohort -na 5 -nt 10 -nd 100000 -nm 1 -age_mature 0)
+set_tests_properties(testTaskStepFarmingCohortNa5Nt10Nw3Mature0 PROPERTIES PASS_REGULAR_EXPRESSION "checksum: 32500000")
+
+add_test(NAME testTaskStepFarmingCohortNa5Nt10Nw3Mature1 COMMAND mpiexec -n 4 ./testTaskStepFarmingCohort -na 5 -nt 10 -nd 100000 -nm 1 -age_mature 1)
+set_tests_properties(testTaskStepFarmingCohortNa5Nt10Nw3Mature1 PROPERTIES PASS_REGULAR_EXPRESSION "checksum: 32500000")
 
 add_test(NAME testTaskStepFarmingCohortNa5Nt10Nw3 COMMAND mpiexec -n 4 ./testTaskStepFarmingCohort -na 5 -nt 10 -nd 100000 -nm 1)
 set_tests_properties(testTaskStepFarmingCohortNa5Nt10Nw3 PROPERTIES PASS_REGULAR_EXPRESSION "checksum: 32500000")

--- a/tests/testTaskStepFarmingCohortAPlus.cxx
+++ b/tests/testTaskStepFarmingCohortAPlus.cxx
@@ -21,10 +21,16 @@
  * @param step step in the task
  * @return index
  */
-int inline getChunkId(int task_id, int step, int numAgeGroups) {
-    int row = task_id + step - numAgeGroups + 1;
-    int col = task_id % numAgeGroups;
-    return row * numAgeGroups + col;
+int inline getChunkId(int task_id, int step, int numAgeGroups, int numTimeSteps) {
+    if (task_id >= 0) {
+        // normal cohort
+        int row = task_id + step - numAgeGroups + 1;
+        int col = task_id % numAgeGroups;
+        return row * numAgeGroups + col;
+    } else {
+        // A+, append at the end. Assume each A+ cohort has a single step == 0
+        return numAgeGroups * numTimeSteps + std::abs(task_id) - 1;
+    }
 }
 
 // Task for the workers to execute
@@ -35,10 +41,17 @@ int inline getChunkId(int task_id, int step, int numAgeGroups) {
  * @param stepEnd last step index (exclusive)
  * @param comm MPI communicator
  * @param ms Sleep # milliseconds
+ * @param numAgeGroups number of age groups
+ * @param numTimeSteps number of time steps
+ * @param numData number of doubles to send to manager
+ * @param dataCollector
+ * @param dependencyMap
+ * @param rng
+ * @param dist
  */
 void inline 
 taskFunction(int task_id, int stepBeg, int stepEnd, MPI_Comm comm, 
-    int ms, int numAgeGroups, int numData, 
+    int ms, int numAgeGroups, int numTimeSteps, int numData, 
     DistDataCollector* dataCollector, // need to be a pointer, or else provide a copy constructor
     std::map<int, std::set<std::array<int, 2>>>* dependencyMap,
     std::mt19937* rng, std::gamma_distribution<double>* dist) {
@@ -49,9 +62,10 @@ taskFunction(int task_id, int stepBeg, int stepEnd, MPI_Comm comm,
     // Initial conditions from the other cohorts
 
     std::fill(localData.begin(), localData.end(), 0.0);
+    
     for (const auto& [task_id2, step] : (*dependencyMap)[task_id]) {
 
-        int chunk_id = getChunkId(task_id2, step, numAgeGroups);
+        int chunk_id = getChunkId(task_id2, step, numAgeGroups, numTimeSteps);
 
         // fetch the data
         dataCollector->get(chunk_id, data.data());
@@ -68,6 +82,7 @@ taskFunction(int task_id, int stepBeg, int stepEnd, MPI_Comm comm,
     }
 
     // step through...
+
     for (auto step = stepBeg; step < stepEnd; ++step) {
 
         // Perform the work, just sleeping here zzzzzzz
@@ -80,7 +95,9 @@ taskFunction(int task_id, int stepBeg, int stepEnd, MPI_Comm comm,
         // Send the data to the manager. Here, the data are 
         // collected row by row. The entry into the collected 
         // array is at index chunk_id.
-        int chunk_id = getChunkId(task_id, step, numAgeGroups);
+        int chunk_id = getChunkId(task_id, step, numAgeGroups, numTimeSteps);
+
+        // send the data to the manager
         dataCollector->put(chunk_id, localData.data());
 
         // E.g.
@@ -141,7 +158,8 @@ int main(int argc, char** argv) {
     std::gamma_distribution<double> dist(k, theta);
 
     // analyze the cohort Id task dependencies
-    SeapodymCohortDependencyAnalyzer taskDeps(numAgeGroups, numTimeSteps, ageMature);
+    const bool aPlusCohort = true;
+    SeapodymCohortDependencyAnalyzer taskDeps(numAgeGroups, numTimeSteps, ageMature, aPlusCohort);
     int numCohorts = taskDeps.getNumberOfCohorts();
     int numCohortSteps = taskDeps.getNumberOfCohortSteps();
     std::map<int, int> stepBegMap = taskDeps.getStepBegMap();
@@ -150,6 +168,7 @@ int main(int argc, char** argv) {
 
     // print the dependencies for debugging
     if (workerId == 0) {
+        std::cout << "Number of age groups: " << numAgeGroups << " number of time steps: " << numTimeSteps << " number of doubles per chunk: " << numData << '\n';
         for (const auto& [task_id, stepBeg] : stepBegMap) {
             int globalTimeIndex = std::max(0, task_id - numAgeGroups + 1);
             std::cout << "At time " << globalTimeIndex << " Task " << task_id << " has steps " << stepBeg << "..." << stepEndMap.at(task_id) - 1 << " and depends on: ";
@@ -160,8 +179,8 @@ int main(int argc, char** argv) {
         }
     }
 
-    // set up the data collector
-    int numChunks = numAgeGroups * numTimeSteps;
+    // set up the data collector, includes the A+ group
+    int numChunks = (numAgeGroups + 1) * numTimeSteps;
     DistDataCollector dataCollect(MPI_COMM_WORLD, numChunks, numData);
 
     // workers expect a function that takes a 4 arguments. We bind the last
@@ -173,13 +192,13 @@ int main(int argc, char** argv) {
         std::placeholders::_4, // comm
         milliseconds,
         numAgeGroups,
+        numTimeSteps,
         numData,
         &dataCollect,
         &dependencyMap,
         &rng,
         &dist);
 
-    
 
     TaskStepWorker worker(MPI_COMM_WORLD, taskFunc, stepBegMap, stepEndMap);
     // sync the manager and workers
@@ -234,6 +253,7 @@ int main(int argc, char** argv) {
             for (auto i = 0; i < numSize; ++i) {
                 checksum += data[chunk*numSize + i];
             }
+            printf("checksum after chunk %d is %.0lf\n", chunk, checksum);
         }
         printf("\nchecksum: %.0lf\n", checksum);
     }

--- a/tests/testTaskStepFarmingCohortAPlus.cxx
+++ b/tests/testTaskStepFarmingCohortAPlus.cxx
@@ -249,11 +249,24 @@ int main(int argc, char** argv) {
         double* data = dataCollect.getCollectedDataPtr();
         int numSize = dataCollect.getNumSize();
         double checksum = 0;
-        for (auto chunk = 0; chunk < dataCollect.getNumChunks(); ++chunk) {\
-            for (auto i = 0; i < numSize; ++i) {
-                checksum += data[chunk*numSize + i];
+        // sum the cohorts' contributions
+        for (auto& [task_id, stepBeg] : stepBegMap) {
+            if (task_id < 0) continue; // A+ handled separately below
+            int stepEnd = stepEndMap.at(task_id);
+            for (auto step = stepBeg; step < stepEnd; ++step) {
+                int chunk_id = getChunkId(task_id, step, numAgeGroups, numTimeSteps);
+                double taskStepChecksum = std::accumulate(&data[chunk_id*numSize], &data[(chunk_id + 1)*numSize], 0.0);
+                checksum += taskStepChecksum;
+                printf("checksum after chunk %d (task_id=%d step=%d) is %.0lf\n", chunk_id, task_id, step, checksum);
             }
-            printf("checksum after chunk %d is %.0lf\n", chunk, checksum);
+        }
+        // now add the A+ contributions
+        for (auto task_id = -numTimeSteps; task_id < 0; ++task_id) {
+            // only one step (0)
+            int chunk_id = getChunkId(task_id, 0, numAgeGroups, numTimeSteps);
+            double taskStepChecksum = std::accumulate(&data[chunk_id*numSize], &data[(chunk_id + 1)*numSize], 0.0);
+            checksum += taskStepChecksum;
+            printf("checksum after A+ chunk %d (task_id=%d) is %.0lf\n", chunk_id, task_id, checksum);
         }
         printf("\nchecksum: %.0lf\n", checksum);
     }


### PR DESCRIPTION
This involves changes in SeapodymCohortDependecyAnalizer. The A+ cohort is represented at each time step as a separate cohort with task_id = -1, -2, -3, .... -numTimeSteps. The dependency map now has entries -timeStep-1: (timeStep, numAgeGroups - 1), (-timeStep, 0). The A+ data (numTimeSteps * numData) are written at the end in the order task_id = -1, -2, ....-numTimeSteps